### PR TITLE
Fixed broken link in Resources section

### DIFF
--- a/BANKI-template.md
+++ b/BANKI-template.md
@@ -927,7 +927,7 @@ When talking through a whiteboard problem or a coding challenge with an intervie
 
 - [https://eloquentjavascript.net/](https://eloquentjavascript.net/)
 - [https://github.com/getify/You-Dont-Know-JS](https://github.com/getify/You-Dont-Know-JS)
-- [https://github.com/yangshun/front-end-interview-handbook](https://github.com/yangshun/front-end-int- erview-handbook)
+- [https://github.com/yangshun/front-end-interview-handbook](https://github.com/yangshun/front-end-interview-handbook)
 - [https://medium.com/javascript-scene/10-interview-questions-every-javascript-developer-should-know-6fa6bdf5ad95](https://medium.com/javascript-scene/10-interview-questions-every-javascript-developer-should-know-6fa6bdf5ad95)
 - [https://www.simplilearn.com/node-js-interview-questions-and-answers-article](https://www.simplilearn.com/node-js-interview-questions-and-answers-article)
 - [https://medium.com/@vigowebs/frequently-asked-node-js-interview-questions-and-answers-b74fa1f20678](https://medium.com/@vigowebs/frequently-asked-node-js-interview-questions-and-answers-b74fa1f20678)


### PR DESCRIPTION
Fix for issue #2 "Typo in the Resources Section"

Just a small typo fix for the Front End Interview Handbook link that was broken in the Resources Section. Not much but hope this helps! 

![](https://c.tenor.com/sH_KNNF07EoAAAAC/honest-word-its-honest-work.gif)

